### PR TITLE
Change from es5 target to es6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,27 +1,56 @@
-# Editor config
-# http://EditorConfig.org
+# EditorConfig is awesome: http://EditorConfig.org
 
 # This EditorConfig overrides any parent EditorConfigs
 root = true
 
 # Default rules applied to all file types
 [*]
-
-# No trailing spaces, newline at EOF
 charset = utf-8
+end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
-end_of_line = lf
-
-# 2 space indentation
 indent_style = space
 indent_size = 2
+max_line_length = 80
+tab_width = 2
+quote_type = double
 
-# JavaScript-specific settings
+# JavaScript and TypeScript-specific settings
 [*.{js,ts}]
 quote_type = single
+indent_size = 2
 continuation_indent_size = 2
 curly_bracket_next_line = false
 indent_brace_style = BSD
 spaces_around_operators = true
 spaces_around_brackets = none
+max_line_length = 100
+
+# JSON-specific settings
+[*.json]
+indent_style = space
+indent_size = 2
+quote_type = double
+
+# Markdown-specific settings
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = off
+quote_type = double
+
+# YAML-specific settings
+[*.yaml,*.yml]
+indent_style = space
+indent_size = 2
+
+# HTML-specific settings
+[*.html]
+indent_style = space
+indent_size = 2
+max_line_length = 120
+
+# Python-specific settings
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 79

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treads",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treads",
-      "version": "1.4.5",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@types/bootstrap": "^5.2.10",
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.1.tgz",
-      "integrity": "sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.5.0.tgz",
-      "integrity": "sha512-A7+AOT2ICkodvtsWnxZP4Xxk3NbZ3VMHd8oihydLRGrJgqqdEz1qSeEgXYyT/Cu8h1TWWsQRejIx48mtjZ5y1w==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.6.0.tgz",
+      "integrity": "sha512-D9B0/3vNg44ZeWbYMpBoXqNP4j6eQD5vNwIlGAuFRRzK/WtT/jvDQW3Bi9kkf3PMDMlM7Yi+73VLUsn5bJcl8A==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -305,9 +305,9 @@
       }
     },
     "node_modules/@jsonjoy.com/util": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.1.3.tgz",
-      "integrity": "sha512-g//kkF4kOwUjemValCtOc/xiYzmwMRmWq3Bn+YnzOzuZLHq2PpMOxxIayN3cKbo7Ko2Np65t6D9H81IvXbXhqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-4B8B+3vFsY4eo33DMKyJPlQ3sBMpPFUZK2dr3O3rXrOGKKbYG44J0XSFkDo1VOQiri5HFEhIeVvItjR2xcazmg==",
       "dev": true,
       "engines": {
         "node": ">=10.0"
@@ -567,9 +567,9 @@
       }
     },
     "node_modules/@types/d3-force": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.9.tgz",
-      "integrity": "sha512-IKtvyFdb4Q0LWna6ymywQsEYjK/94SGhPrMfEr1TIc5OBeziTi+1jcCvttts8e0UWZIxpasjnQk9MNk/3iS+kA=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="
     },
     "node_modules/@types/d3-format": {
       "version": "3.0.4",
@@ -721,9 +721,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
-      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -794,9 +794,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
-      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -893,16 +893,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.13.0.tgz",
-      "integrity": "sha512-FX1X6AF0w8MdVFLSdqwqN/me2hyhuQg4ykN6ZpVhh1ij/80pTvDKclX1sZB9iqex8SjQfVhwMKs3JtnnMLzG9w==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.14.1.tgz",
+      "integrity": "sha512-aAJd6bIf2vvQRjUG3ZkNXkmBpN+J7Wd0mfQiiVCJMu9Z5GcZZdcc0j8XwN/BM97Fl7e3SkTXODSk4VehUv7CGw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/type-utils": "7.13.0",
-        "@typescript-eslint/utils": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/type-utils": "7.14.1",
+        "@typescript-eslint/utils": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -926,15 +926,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.13.0.tgz",
-      "integrity": "sha512-EjMfl69KOS9awXXe83iRN7oIEXy9yYdqWfqdrFAYAAr6syP8eLEFI7ZE4939antx2mNgPRW/o1ybm2SFYkbTVA==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.14.1.tgz",
+      "integrity": "sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/typescript-estree": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/typescript-estree": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -954,13 +954,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.13.0.tgz",
-      "integrity": "sha512-ZrMCe1R6a01T94ilV13egvcnvVJ1pxShkE0+NDjDzH4nvG1wXpwsVI5bZCvE7AEDH1mXEx5tJSVR68bLgG7Dng==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.14.1.tgz",
+      "integrity": "sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0"
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -971,13 +971,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.13.0.tgz",
-      "integrity": "sha512-xMEtMzxq9eRkZy48XuxlBFzpVMDurUAfDu5Rz16GouAtXm0TaAoTFzqWUFPPuQYXI/CDaH/Bgx/fk/84t/Bc9A==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.14.1.tgz",
+      "integrity": "sha512-/MzmgNd3nnbDbOi3LfasXWWe292+iuo+umJ0bCCMCPc1jLO/z2BQmWUUUXvXLbrQey/JgzdF/OV+I5bzEGwJkQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "7.13.0",
-        "@typescript-eslint/utils": "7.13.0",
+        "@typescript-eslint/typescript-estree": "7.14.1",
+        "@typescript-eslint/utils": "7.14.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -998,9 +998,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.13.0.tgz",
-      "integrity": "sha512-QWuwm9wcGMAuTsxP+qz6LBBd3Uq8I5Nv8xb0mk54jmNoCyDspnMvVsOxI6IsMmway5d1S9Su2+sCKv1st2l6eA==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1011,13 +1011,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.13.0.tgz",
-      "integrity": "sha512-cAvBvUoobaoIcoqox1YatXOnSl3gx92rCZoMRPzMNisDiM12siGilSM4+dJAekuuHTibI2hVC2fYK79iSFvWjw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.14.1.tgz",
+      "integrity": "sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/visitor-keys": "7.13.0",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/visitor-keys": "7.14.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1092,15 +1092,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.13.0.tgz",
-      "integrity": "sha512-jceD8RgdKORVnB4Y6BqasfIkFhl4pajB1wVxrF4akxD2QPM8GNYjgGwEzYS+437ewlqqrg7Dw+6dhdpjMpeBFQ==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.14.1.tgz",
+      "integrity": "sha512-CMmVVELns3nak3cpJhZosDkm63n+DwBlDX8g0k4QUa9BMnF+lH2lr3d130M1Zt1xxmB3LLk3NV7KQCq86ZBBhQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "7.13.0",
-        "@typescript-eslint/types": "7.13.0",
-        "@typescript-eslint/typescript-estree": "7.13.0"
+        "@typescript-eslint/scope-manager": "7.14.1",
+        "@typescript-eslint/types": "7.14.1",
+        "@typescript-eslint/typescript-estree": "7.14.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -1114,12 +1114,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.13.0.tgz",
-      "integrity": "sha512-nxn+dozQx+MK61nn/JP+M4eCkHDSxSLDpgE3WcQo0+fkjEolnaB5jswvIKC4K56By8MMgIho7f1PVxERHEo8rw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.14.1.tgz",
+      "integrity": "sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "7.13.0",
+        "@typescript-eslint/types": "7.14.1",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001634",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001634.tgz",
-      "integrity": "sha512-fbBYXQ9q3+yp1q1gBk86tOFs4pyn/yxFm5ZNP18OXJDfA3txImOY9PhfxVggZ4vRHDqoU8NrKU81eN0OtzOgRA==",
+      "version": "1.0.30001639",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz",
+      "integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==",
       "dev": true,
       "funding": [
         {
@@ -2227,13 +2227,13 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.2.tgz",
-      "integrity": "sha512-LXm/Xx6TNLzfHM2lBaIQHfvtdW5QfdbyLzfJAWZrclCAb47yVa0/yJG69+amcw3Lq0YZ+kyU40rbsMPLcMt9aw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.0.3.tgz",
+      "integrity": "sha512-lsekJctOTqdCn4cNrtrSwsuMR/fHC+oiVMHkp/OugBWtwjH8XJag1/OtGaYJGtz0un1fQcRy4ryfYTQsfh+KSQ==",
       "dev": true,
       "dependencies": {
-        "cssnano-preset-default": "^7.0.2",
-        "lilconfig": "^3.1.1"
+        "cssnano-preset-default": "^7.0.3",
+        "lilconfig": "^3.1.2"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -2247,38 +2247,38 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.2.tgz",
-      "integrity": "sha512-z95kGKZx8VWHfERj7LFzuiTxylbvEp07ZEYaFu+t6bFyNOXLd/+3oPyNaY7ISwcrfHFCkt8OfRo4IZxVRJZ7dg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.3.tgz",
+      "integrity": "sha512-dQ3Ba1p/oewICp/szF1XjFFgql8OlOBrI2YNBUUwhHQnJNoMOcQTa+Bi7jSJN8r/eM1egW0Ud1se/S7qlduWKA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.23.1",
         "css-declaration-sorter": "^7.2.0",
         "cssnano-utils": "^5.0.0",
         "postcss-calc": "^10.0.0",
-        "postcss-colormin": "^7.0.0",
-        "postcss-convert-values": "^7.0.0",
-        "postcss-discard-comments": "^7.0.0",
+        "postcss-colormin": "^7.0.1",
+        "postcss-convert-values": "^7.0.1",
+        "postcss-discard-comments": "^7.0.1",
         "postcss-discard-duplicates": "^7.0.0",
         "postcss-discard-empty": "^7.0.0",
         "postcss-discard-overridden": "^7.0.0",
-        "postcss-merge-longhand": "^7.0.1",
-        "postcss-merge-rules": "^7.0.1",
+        "postcss-merge-longhand": "^7.0.2",
+        "postcss-merge-rules": "^7.0.2",
         "postcss-minify-font-values": "^7.0.0",
         "postcss-minify-gradients": "^7.0.0",
-        "postcss-minify-params": "^7.0.0",
-        "postcss-minify-selectors": "^7.0.1",
+        "postcss-minify-params": "^7.0.1",
+        "postcss-minify-selectors": "^7.0.2",
         "postcss-normalize-charset": "^7.0.0",
         "postcss-normalize-display-values": "^7.0.0",
         "postcss-normalize-positions": "^7.0.0",
         "postcss-normalize-repeat-style": "^7.0.0",
         "postcss-normalize-string": "^7.0.0",
         "postcss-normalize-timing-functions": "^7.0.0",
-        "postcss-normalize-unicode": "^7.0.0",
+        "postcss-normalize-unicode": "^7.0.1",
         "postcss-normalize-url": "^7.0.0",
         "postcss-normalize-whitespace": "^7.0.0",
-        "postcss-ordered-values": "^7.0.0",
-        "postcss-reduce-initial": "^7.0.0",
+        "postcss-ordered-values": "^7.0.1",
+        "postcss-reduce-initial": "^7.0.1",
         "postcss-reduce-transforms": "^7.0.0",
         "postcss-svgo": "^7.0.1",
         "postcss-unique-selectors": "^7.0.1"
@@ -2962,9 +2962,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.803",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.803.tgz",
-      "integrity": "sha512-61H9mLzGOCLLVsnLiRzCbc63uldP0AniRYPV3hbGVtONA1pI7qSGILdbofR7A8TMbOypDocEAjH/e+9k1QIe3g==",
+      "version": "1.4.815",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.815.tgz",
+      "integrity": "sha512-OvpTT2ItpOXJL7IGcYakRjHCt8L5GrrN/wHCQsRB4PQa1X9fe+X9oen245mIId7s14xvArCGSTIq644yPUKKLg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3047,9 +3047,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.3.tgz",
-      "integrity": "sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
+      "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
       "dev": true
     },
     "node_modules/escalade": {
@@ -3731,9 +3731,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
-      "integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+      "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
       "dev": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^2.1.0",
@@ -4201,12 +4201,15 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.14.0.tgz",
+      "integrity": "sha512-a5dFJih5ZLYlRtDc0dZWP7RiKr6xIKzmn/oAYCDvdLThadVgyJwlaoQPmRtMSpz+rk0OGAgIu+TcM9HUF0fk1A==",
       "dev": true,
       "dependencies": {
-        "hasown": "^2.0.0"
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4509,9 +4512,9 @@
       }
     },
     "node_modules/launch-editor": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.1.tgz",
-      "integrity": "sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.8.0.tgz",
+      "integrity": "sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==",
       "dev": true,
       "dependencies": {
         "picocolors": "^1.0.0",
@@ -4615,9 +4618,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
+      "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
@@ -4906,10 +4909,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5055,6 +5061,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "dev": true
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -5247,9 +5259,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.38",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
-      "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+      "version": "8.4.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
       "dev": true,
       "funding": [
         {
@@ -5267,7 +5279,7 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "source-map-js": "^1.2.0"
       },
       "engines": {
@@ -5291,12 +5303,12 @@
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.0.tgz",
-      "integrity": "sha512-5CN6fqtsEtEtwf3mFV3B4UaZnlYljPpzmGeDB4yCK067PnAtfLe9uX2aFZaEwxHE7HopG5rUkW8gyHrNAesHEg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.1.tgz",
+      "integrity": "sha512-uszdT0dULt3FQs47G5UHCduYK+FnkLYlpu1HpWu061eGsKZ7setoG7kA+WC9NQLsOJf69D5TxGHgnAdRgylnFQ==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.23.1",
         "caniuse-api": "^3.0.0",
         "colord": "^2.9.3",
         "postcss-value-parser": "^4.2.0"
@@ -5309,12 +5321,12 @@
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.0.tgz",
-      "integrity": "sha512-bMuzDgXBbFbByPgj+/r6va8zNuIDUaIIbvAFgdO1t3zdgJZ77BZvu6dfWyd6gHEJnYzmeVr9ayUsAQL3/qLJ0w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.1.tgz",
+      "integrity": "sha512-9x2ofb+hYPwHWMlWAzyWys2yMDZYGfkX9LodbaVTmLdlupmtH2AGvj8Up95wzzNPRDEzPIxQIkUaPJew3bT6xA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.23.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -5325,10 +5337,13 @@
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.0.tgz",
-      "integrity": "sha512-xpSdzRqYmy4YIVmjfGyYXKaI1SRnK6CTr+4Zmvyof8ANwvgfZgGdVtmgAvzh59gJm808mJCWQC9tFN0KF5dEXA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.1.tgz",
+      "integrity": "sha512-GVrQxUOhmle1W6jX2SvNLt4kmN+JYhV7mzI6BMnkAWR9DtVvg8e67rrV0NfdWhn7x1zxvzdWkMBPdBDCls+uwQ==",
       "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.0"
+      },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
       },
@@ -5373,13 +5388,13 @@
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.1.tgz",
-      "integrity": "sha512-qZlD26hnqSTMxSSOMS8+QCeRWtqOdMKeQHvHcBhjL3mJxKUs47cvO1Y1x3iTdYIk3ioMcRHTiy229TT0mEMH/A==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.2.tgz",
+      "integrity": "sha512-06vrW6ZWi9qeP7KMS9fsa9QW56+tIMW55KYqF7X3Ccn+NI2pIgPV6gFfvXTMQ05H90Y5DvnCDPZ2IuHa30PMUg==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^7.0.1"
+        "stylehacks": "^7.0.2"
       },
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -5389,12 +5404,12 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.1.tgz",
-      "integrity": "sha512-bb8McYQbo2etgs0uVt6AfngajACK3FHSVP3sGLhprrjbtHJWgG03JZ4KKBlJ8/5Fb8/Rr+mMKaybMYeoYrAg0A==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.2.tgz",
+      "integrity": "sha512-VAR47UNvRsdrTHLe7TV1CeEtF9SJYR5ukIB9U4GZyZOptgtsS20xSxy+k5wMrI3udST6O1XuIn7cjQkg7sDAAw==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.23.1",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^5.0.0",
         "postcss-selector-parser": "^6.1.0"
@@ -5439,12 +5454,12 @@
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.0.tgz",
-      "integrity": "sha512-XOJAuX8Q/9GT1sGxlUvaFEe2H9n50bniLZblXXsAT/BwSfFYvzSZeFG7uupwc0KbKpTnflnQ7aMwGzX6JUWliQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.1.tgz",
+      "integrity": "sha512-e+Xt8xErSRPgSRFxHeBCSxMiO8B8xng7lh8E0A5ep1VfwYhY8FXhu4Q3APMjgx9YDDbSp53IBGENrzygbUvgUQ==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.23.1",
         "cssnano-utils": "^5.0.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -5456,11 +5471,12 @@
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.1.tgz",
-      "integrity": "sha512-YfIbGtcgMFquPxV2L/ASs36ZS4DsgfcDX9tQ8cTEIvBTv+0GXFKtcvvpi9tCKto/+DWGWYKMCESFG3Pnan0Feg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.2.tgz",
+      "integrity": "sha512-dCzm04wqW1uqLmDZ41XYNBJfjgps3ZugDpogAmJXoCb5oCiTzIX4oPXXKxDpTvWOnKxQKR4EbV4ZawJBLcdXXA==",
       "dev": true,
       "dependencies": {
+        "cssesc": "^3.0.0",
         "postcss-selector-parser": "^6.1.0"
       },
       "engines": {
@@ -5617,12 +5633,12 @@
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.0.tgz",
-      "integrity": "sha512-OnKV52/VFFDAim4n0pdI+JAhsolLBdnCKxE6VV5lW5Q/JeVGFN8UM8ur6/A3EAMLsT1ZRm3fDHh/rBoBQpqi2w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.1.tgz",
+      "integrity": "sha512-PTPGdY9xAkTw+8ZZ71DUePb7M/Vtgkbbq+EoI33EuyQEzbKemEQMhe5QSr0VP5UfZlreANDPxSfcdSprENcbsg==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.23.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -5663,9 +5679,9 @@
       }
     },
     "node_modules/postcss-ordered-values": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.0.tgz",
-      "integrity": "sha512-KROvC63A8UQW1eYDljQe1dtwc1E/M+mMwDT6z7khV/weHYLWTghaLRLunU7x1xw85lWFwVZOAGakxekYvKV+0w==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.1.tgz",
+      "integrity": "sha512-irWScWRL6nRzYmBOXReIKch75RRhNS86UPUAxXdmW/l0FcAsg0lvAXQCby/1lymxn/o0gVa6Rv/0f03eJOwHxw==",
       "dev": true,
       "dependencies": {
         "cssnano-utils": "^5.0.0",
@@ -5679,12 +5695,12 @@
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.0.tgz",
-      "integrity": "sha512-iqGgmBxY9LrblZ0BKLjmrA1mC/cf9A/wYCCqSmD6tMi+xAyVl0+DfixZIHSVDMbCPRPjNmVF0DFGth/IDGelFQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.1.tgz",
+      "integrity": "sha512-0JDUSV4bGB5FGM5g8MkS+rvqKukJZ7OTHw/lcKn7xPNqeaqJyQbUO8/dJpvyTpaVwPsd3Uc33+CfNzdVowp2WA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.23.1",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
@@ -6678,12 +6694,12 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.1.tgz",
-      "integrity": "sha512-PnrT4HzajnxbjfChpeBKLSpSykilnGBlD+pIffCoT5KbLur9fcL8uKRQJJap85byR2wCYZl/4Otk5eq76qeZxQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.2.tgz",
+      "integrity": "sha512-HdkWZS9b4gbgYTdMg4gJLmm7biAUug1qTqXjS+u8X+/pUd+9Px1E+520GnOW3rST9MNsVOVpsJG+mPHNosxjOQ==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.23.1",
         "postcss-selector-parser": "^6.1.0"
       },
       "engines": {
@@ -6973,9 +6989,9 @@
       }
     },
     "node_modules/tree-dump": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.1.tgz",
-      "integrity": "sha512-WCkcRBVPSlHHq1dc/px9iOfqklvzCbdRwvlNfxGZsrHqf6aZttfPrd7DJTt6oR10dwUfpFFQeVTkPbBIZxX/YA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+      "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0"
@@ -7073,9 +7089,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -7086,14 +7102,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.13.0.tgz",
-      "integrity": "sha512-upO0AXxyBwJ4BbiC6CRgAJKtGYha2zw4m1g7TIVPSonwYEuf7vCicw3syjS1OxdDMTz96sZIXl3Jx3vWJLLKFw==",
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-7.14.1.tgz",
+      "integrity": "sha512-Eo1X+Y0JgGPspcANKjeR6nIqXl4VL5ldXLc15k4m9upq+eY5fhU2IueiEZL6jmHrKH8aCfbIvM/v3IrX5Hg99w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "7.13.0",
-        "@typescript-eslint/parser": "7.13.0",
-        "@typescript-eslint/utils": "7.13.0"
+        "@typescript-eslint/eslint-plugin": "7.14.1",
+        "@typescript-eslint/parser": "7.14.1",
+        "@typescript-eslint/utils": "7.14.1"
       },
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
@@ -7239,9 +7255,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.92.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.0.tgz",
-      "integrity": "sha512-Bsw2X39MYIgxouNATyVpCNVWBCuUwDgWtN78g6lSdPJRLaQ/PUVm/oXcaRAyY/sMFoKFQrsPeqvTizWtq7QPCA==",
+      "version": "5.92.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
+      "integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -7437,15 +7453,16 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/glob": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
         "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^1.11.1"
       },
       "bin": {
@@ -7459,9 +7476,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -7708,9 +7725,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treads",
-  "version": "1.4.6",
+  "version": "1.5.0",
   "description": "A top down game of mini tanks",
   "keywords": [
     "game",
@@ -18,7 +18,6 @@
   "license": "MIT",
   "author": "Steven Parrill <sparrill14@gmail.com> (https://github.com/sparrill14)",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "webpack serve --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "build:dev": "webpack --config webpack.dev.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
       // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
   
       /* Language and Environment */
-      "target": "es5",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+      "target": "es6",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
       // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
       // "jsx": "preserve",                                /* Specify what JSX code is generated. */
       // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
## Description
This pull request switches the typescript compilation target from es5 to es6. The editor config was also updated with more comprehensive settings.

### Issue
N/A

### Type of Change
- New feature

### Context
This project leverages es6 features extensively so it makes sense to switch. 

- **Dependencies:** NPM audit fix and NPM update both run
- **Backward Compatibility:** es5 & es6 are supported by all modern browsers
